### PR TITLE
ENH: Add default atlas files to extension package and make atlas selection optional

### DIFF
--- a/SwissSkullStripper/CMakeLists.txt
+++ b/SwissSkullStripper/CMakeLists.txt
@@ -68,3 +68,19 @@ if(BUILD_TESTING)
   add_subdirectory(Testing)
 endif()
 
+# Add default atlas files to binary directory and extension package
+
+set(DEFAULT_ATLAS_FILES
+  atlasImage.mha
+  atlasMask.mha
+  )
+
+foreach(DEFAULT_ATLAS_FILE ${DEFAULT_ATLAS_FILES})
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Data/Input/${DEFAULT_ATLAS_FILE}
+    ${CMAKE_BINARY_DIR}/${Slicer_CLIMODULES_BIN_DIR}/SwissSkullStripperDefaultAtlas/${DEFAULT_ATLAS_FILE}
+    COPYONLY)
+  install(
+    FILES ${CMAKE_BINARY_DIR}/${Slicer_CLIMODULES_BIN_DIR}/${DEFAULT_ATLAS_FILE}
+    DESTINATION ${Slicer_INSTALL_CLIMODULES_BIN_DIR}/SwissSkullStripperDefaultAtlas COMPONENT Runtime)
+endforeach()

--- a/SwissSkullStripper/SwissSkullStripper.xml
+++ b/SwissSkullStripper/SwissSkullStripper.xml
@@ -9,24 +9,6 @@
   <contributor>Bill Lorensen (Noware)</contributor>
   <acknowledgements>This work is based the Skull-Stripper Filter for ITK, Stefan Bauer, Thomas Fejes and Mauricio Reyes, Institute for Surgical Technology and Biomechanics, University of Bern, Switzerland</acknowledgements>
   <parameters>
-    <label>Atlas</label>
-    <description><![CDATA[Atlas and Atlas Mask]]></description>
-    <image>
-      <name>atlasMRIVolume</name>
-      <label>Atlas Volume</label>
-      <channel>input</channel>
-      <description><![CDATA[Atlas Volume. Usually an MRI of the head, but CT of the head may work.]]></description>
-      <longflag>atlasMRI</longflag>
-    </image>
-    <image type="label">
-      <name>atlasMaskVolume</name>
-      <label>Atlas Mask Volume</label>
-      <channel>input</channel>
-      <description><![CDATA[Atlas Mask Volume that masks the brain.]]></description>
-      <longflag>atlasMask</longflag>
-    </image>
-  </parameters>
-  <parameters>
     <label>Input</label>
     <description><![CDATA[Input volumes]]></description>
     <image>
@@ -52,6 +34,24 @@
       <channel>output</channel>
       <index>2</index>
       <description><![CDATA[The brain mask that contains the patient's brain]]></description>
+    </image>
+  </parameters>
+  <parameters advanced="true">
+    <label>Atlas</label>
+    <description><![CDATA[Atlas and Atlas Mask]]></description>
+    <image>
+      <name>atlasMRIVolume</name>
+      <label>Atlas Volume</label>
+      <channel>input</channel>
+      <description><![CDATA[Atlas Volume. Usually an MRI of the head, but CT of the head may work. If not specified, a default MRI atlas will be used.]]></description>
+      <longflag>atlasMRI</longflag>
+    </image>
+    <image type="label">
+      <name>atlasMaskVolume</name>
+      <label>Atlas Mask Volume</label>
+      <channel>input</channel>
+      <description><![CDATA[Atlas Mask Volume that masks the brain. If not specified, a default MRI atlas will be used.]]></description>
+      <longflag>atlasMask</longflag>
     </image>
   </parameters>
 </executable>


### PR DESCRIPTION
Atlas files (atlasImage.mha and atlasMask.mha) are added to the package
in SwissSkullStripperDefaultAtlas folder. If user does not specify atlas
then these default files are used.